### PR TITLE
Prevent crash in AMR-NB encoder when invalid CMR received.

### DIFF
--- a/codecs/codec_amr.c
+++ b/codecs/codec_amr.c
@@ -198,12 +198,11 @@ static int amrtolin_framein(struct ast_trans_pvt *pvt, struct ast_frame *f)
 	unsigned char temp[f->datalen];
 	unsigned char *in = f->data.ptr;
 
-	if (attr && mode_next < 15) {
-		if((8000 == sample_rate && mode_next > 7) || (16000 == sample_rate && mode_next > 8)){
-			ast_log(LOG_WARNING, "Invalid CMR: %d (sample rate %d frame length %d)\n", mode_next, sample_rate, f->datalen);
-		} else {
+	if (attr) {
+		if (8000 == sample_rate && mode_next <= 7) {
 			attr->mode_current = mode_next;
-			ast_debug(3, "AMR CMR request to mode %d\n", attr->mode_current);
+		} else if (16000 == sample_rate && mode_next <= 8)
+			attr->mode_current = mode_next;
 		}
 	}
 

--- a/codecs/codec_amr.c
+++ b/codecs/codec_amr.c
@@ -199,7 +199,12 @@ static int amrtolin_framein(struct ast_trans_pvt *pvt, struct ast_frame *f)
 	unsigned char *in = f->data.ptr;
 
 	if (attr && mode_next < 15) {
-		attr->mode_current = mode_next;
+		if((8000 == sample_rate && mode_next > 7) || (16000 == sample_rate && mode_next > 8)){
+			ast_log(LOG_WARNING, "Invalid CMR: %d (sample rate %d frame length %d)\n", mode_next, sample_rate, f->datalen);
+		} else {
+			attr->mode_current = mode_next;
+			ast_debug(3, "AMR CMR request to mode %d\n", attr->mode_current);
+		}
 	}
 
 	/* 

--- a/codecs/codec_amr.c
+++ b/codecs/codec_amr.c
@@ -201,7 +201,7 @@ static int amrtolin_framein(struct ast_trans_pvt *pvt, struct ast_frame *f)
 	if (attr) {
 		if (8000 == sample_rate && mode_next <= 7) {
 			attr->mode_current = mode_next;
-		} else if (16000 == sample_rate && mode_next <= 8)
+		} else if (16000 == sample_rate && mode_next <= 8) {
 			attr->mode_current = mode_next;
 		}
 	}


### PR DESCRIPTION
For example, if "13" which is unused is received, this is supplied to the encoder causing a segfault.
Now we will only use the CMR value if it is a valid mode, otherwise give a warning and ignore.